### PR TITLE
MP-48/Deploy-Apex-Class-Trigger-for-New-Lead-Assignment-Rule

### DIFF
--- a/unpackaged/main/default/objects/Account/fields/Page_Layout__c.field-meta.xml
+++ b/unpackaged/main/default/objects/Account/fields/Page_Layout__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Page_Layout__c</fullName>
+    <externalId>false</externalId>
+    <label>Page Layout</label>
+    <length>35</length>
+    <required>false</required>
+    <trackFeedHistory>false</trackFeedHistory>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>


### PR DESCRIPTION
## What has changed?
- Added a new custom text field `Page_Layout__c` to the Account object metadata.

## What's the impact of these changes?
- Introduces a new optional text field on Account records with a length limit of 35 characters.
- No immediate impact on existing functionality but enables storing additional layout-related information per Account.
- Downstream processes or integrations referencing Account fields may need to consider this new field if utilized.

## What should reviewers pay attention to?
- Confirm field properties such as length, label, and uniqueness are appropriate.
- Verify no conflicts with existing Account fields or naming conventions.

## Testing recommendations
- Manual testing to create and update Account records with values in the new `Page_Layout__c` field.
- Regression testing on Account-related UI and integrations to ensure no unintended side effects.
- *No unit tests added or modified.*