### PR TITLE
Back-propagated: MP-45/Customer-Satisfaction-Score

### DIFF
--- a/unpackaged/main/default/objects/Account/fields/Customer_Satisfaction_Score__c.field-meta.xml
+++ b/unpackaged/main/default/objects/Account/fields/Customer_Satisfaction_Score__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Customer_Satisfaction_Score__c</fullName>
+    <externalId>false</externalId>
+    <label>Customer Satisfaction Score</label>
+    <length>55</length>
+    <required>false</required>
+    <trackFeedHistory>false</trackFeedHistory>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>


### PR DESCRIPTION
## What has changed?
- Added a new custom text field `Customer_Satisfaction_Score__c` to the Account object.
- Field properties include a length of 55 characters, non-required, non-unique, and no feed history tracking.

## What's the impact of these changes?
- Enables storage of customer satisfaction scores as text on Account records.
- No direct impact on existing functionality or security.
- Potential downstream effects on reports, integrations, or UI components referencing Account fields if they incorporate this new field.

## What should reviewers pay attention to?
- Confirm field length and type are appropriate for intended use.
- Verify no unintended permission or visibility issues arise from the new field.
- Consider if any automation or validation rules need updates to incorporate this field.

## Testing recommendations
- Manual testing to verify the field appears on Account layouts and accepts input.
- Regression testing on Account-related processes to ensure no disruption.
- No unit test changes required as this is a metadata addition only.