### PR TITLE
MP-66/Deprecated-Field

### DIFF
--- a/unpackaged/main/default/objects/Account/fields/Deprecated_Field__c.field-meta.xml
+++ b/unpackaged/main/default/objects/Account/fields/Deprecated_Field__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Deprecated_Field__c</fullName>
+    <externalId>false</externalId>
+    <label>Deprecated Field</label>
+    <length>50</length>
+    <required>false</required>
+    <trackFeedHistory>false</trackFeedHistory>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>


### PR DESCRIPTION
## What has changed?
- Added a new custom text field `Deprecated_Field__c` to the Account object metadata.

## What's the impact of these changes?
- Functional impact is minimal as the field is newly introduced and not marked required.
- No immediate security or performance implications.
- Potential downstream effects include updates needed in integrations, reports, or UI if this field is referenced later.

## What should reviewers pay attention to?
- Confirm the field properties such as length, label, and type are appropriate.
- Verify that the field is not inadvertently set as required or unique.
- Consider if any existing automation or validation rules need to accommodate this new field.

## Testing recommendations
- Manual testing to ensure the field appears correctly on Account records if added to layouts.
- Regression testing on Account-related processes to confirm no unintended side effects.
- No unit test changes required as this is a metadata addition only.