### PR TITLE
CPQ-Feature-Approval

### DIFF
--- a/configdata/Pricebook2/2023_Vehicle_Price_Book_[XAILjLRA00000nDs10].gs.json
+++ b/configdata/Pricebook2/2023_Vehicle_Price_Book_[XAILjLRA00000nDs10].gs.json
@@ -1,0 +1,11 @@
+{
+  "Object": "Pricebook2",
+  "Fields": {
+    "Description": "Vehicle Price Book for 2023 catalogue",
+    "GearsetDisplayName": "2023 Vehicle Price Book",
+    "GearsetExternalId__c": "XAILjLRA00000nDs10",
+    "IsActive": "false",
+    "Name": "2023 Vehicle Price Book"
+  },
+  "References": []
+}

--- a/configdata/PricebookEntry/2023_Vehicle_Price_Book_-_Pickup_Truck_[UAINaEm000000nDu10].gs.json
+++ b/configdata/PricebookEntry/2023_Vehicle_Price_Book_-_Pickup_Truck_[UAINaEm000000nDu10].gs.json
@@ -1,0 +1,26 @@
+{
+  "Object": "PricebookEntry",
+  "Fields": {
+    "GearsetDisplayName": "2023 Vehicle Price Book - Pickup Truck",
+    "GearsetExternalId__c": "UAINaEm000000nDu10",
+    "IsActive": "true",
+    "UnitPrice": "55000.0",
+    "UseStandardPrice": "false"
+  },
+  "References": [
+    {
+      "Name": "Pricebook2",
+      "ReferencedObject": "Pricebook2",
+      "ReferencedFields": {
+        "GearsetExternalId__c": "XAILjLRA00000nDs10"
+      }
+    },
+    {
+      "Name": "Product2",
+      "ReferencedObject": "Product2",
+      "ReferencedFields": {
+        "GearsetExternalId__c": "AAIt5n6500000nDt10"
+      }
+    }
+  ]
+}

--- a/configdata/PricebookEntry/Standard_Price_Book_-_Pickup_Truck_[UAIIaEm000000nDu10].gs.json
+++ b/configdata/PricebookEntry/Standard_Price_Book_-_Pickup_Truck_[UAIIaEm000000nDu10].gs.json
@@ -1,0 +1,26 @@
+{
+  "Object": "PricebookEntry",
+  "Fields": {
+    "GearsetDisplayName": "Standard Price Book - Pickup Truck",
+    "GearsetExternalId__c": "UAIIaEm000000nDu10",
+    "IsActive": "false",
+    "UnitPrice": "60000.0",
+    "UseStandardPrice": "false"
+  },
+  "References": [
+    {
+      "Name": "Pricebook2",
+      "ReferencedObject": "Pricebook2",
+      "ReferencedFields": {
+        "GearsetExternalId__c": "StandardPriceBook"
+      }
+    },
+    {
+      "Name": "Product2",
+      "ReferencedObject": "Product2",
+      "ReferencedFields": {
+        "GearsetExternalId__c": "AAIt5n6500000nDt10"
+      }
+    }
+  ]
+}

--- a/configdata/Product2/002_-_Pickup_Truck_[AAIt5n6500000nDt10].gs.json
+++ b/configdata/Product2/002_-_Pickup_Truck_[AAIt5n6500000nDt10].gs.json
@@ -1,0 +1,149 @@
+{
+  "Object": "Product2",
+  "Fields": {
+    "Description": "",
+    "DisplayUrl": "",
+    "ExternalId": "",
+    "Extras__c": "false",
+    "Family": "Miscellaneous",
+    "GearsetDisplayName": "002 - Pickup Truck",
+    "GearsetExternalId__c": "AAIt5n6500000nDt10",
+    "IsActive": "true",
+    "Name": "Pickup Truck",
+    "ProductCode": "002",
+    "QuantityUnitOfMeasure": "",
+    "SBQQ__AssetAmendmentBehavior__c": "Default",
+    "SBQQ__AssetConversion__c": "One per quote line",
+    "SBQQ__BatchQuantity__c": "",
+    "SBQQ__BillingFrequency__c": "",
+    "SBQQ__BillingType__c": "",
+    "SBQQ__BlockPricingField__c": "Quantity",
+    "SBQQ__ChargeType__c": "",
+    "SBQQ__Component__c": "false",
+    "SBQQ__CompoundDiscountRate__c": "",
+    "SBQQ__ConfigurationEvent__c": "Always",
+    "SBQQ__ConfigurationFieldSet__c": "",
+    "SBQQ__ConfigurationFields__c": "",
+    "SBQQ__ConfigurationFormTitle__c": "",
+    "SBQQ__ConfigurationType__c": "Required",
+    "SBQQ__ConfigurationValidator__c": "",
+    "SBQQ__ConfiguredCodePattern__c": "",
+    "SBQQ__ConfiguredDescriptionPattern__c": "",
+    "SBQQ__CostEditable__c": "false",
+    "SBQQ__CustomConfigurationPage__c": "",
+    "SBQQ__CustomConfigurationRequired__c": "false",
+    "SBQQ__CustomerCommunityAvailability__c": "",
+    "SBQQ__DefaultPricingTable__c": "",
+    "SBQQ__DefaultQuantity__c": "1.0",
+    "SBQQ__DescriptionLocked__c": "false",
+    "SBQQ__DynamicPricingConstraint__c": "",
+    "SBQQ__EnableLargeConfiguration__c": "false",
+    "SBQQ__ExcludeFromMaintenance__c": "false",
+    "SBQQ__ExcludeFromOpportunity__c": "false",
+    "SBQQ__ExternallyConfigurable__c": "false",
+    "SBQQ__GenerateContractedPrice__c": "",
+    "SBQQ__HasConfigurationAttributes__c": "true",
+    "SBQQ__HasConsumptionSchedule__c": "false",
+    "SBQQ__Hidden__c": "false",
+    "SBQQ__HidePriceInSearchResults__c": "false",
+    "SBQQ__IncludeInMaintenance__c": "false",
+    "SBQQ__NewQuoteGroup__c": "false",
+    "SBQQ__NonDiscountable__c": "false",
+    "SBQQ__NonPartnerDiscountable__c": "false",
+    "SBQQ__Optional__c": "false",
+    "SBQQ__OptionLayout__c": "",
+    "SBQQ__OptionSelectionMethod__c": "Click",
+    "SBQQ__PriceEditable__c": "false",
+    "SBQQ__PricingMethodEditable__c": "false",
+    "SBQQ__PricingMethod__c": "List",
+    "SBQQ__ProductPictureID__c": "",
+    "SBQQ__QuantityEditable__c": "true",
+    "SBQQ__QuantityScale__c": "",
+    "SBQQ__ReconfigurationDisabled__c": "false",
+    "SBQQ__SortOrder__c": "",
+    "SBQQ__Specifications__c": "",
+    "SBQQ__SubscriptionBase__c": "List",
+    "SBQQ__SubscriptionCategory__c": "",
+    "SBQQ__SubscriptionPercent__c": "",
+    "SBQQ__SubscriptionPricing__c": "",
+    "SBQQ__SubscriptionTerm__c": "",
+    "SBQQ__SubscriptionType__c": "Renewable",
+    "SBQQ__Taxable__c": "false",
+    "SBQQ__TaxCode__c": "",
+    "SBQQ__TermDiscountLevel__c": "",
+    "SBQQ__UpgradeRatio__c": "",
+    "StockKeepingUnit": ""
+  },
+  "References": [
+    {
+      "Name": "SBQQ__CostSchedule__r",
+      "ReferencedObject": "SBQQ__DiscountSchedule__c",
+      "ReferencedFields": {
+        "GearsetExternalId__c": ""
+      }
+    },
+    {
+      "Name": "SBQQ__DiscountCategory__r",
+      "ReferencedObject": "SBQQ__DiscountCategory__c",
+      "ReferencedFields": {
+        "GearsetExternalId__c": ""
+      }
+    },
+    {
+      "Name": "SBQQ__DiscountSchedule__r",
+      "ReferencedObject": "SBQQ__DiscountSchedule__c",
+      "ReferencedFields": {
+        "GearsetExternalId__c": ""
+      }
+    },
+    {
+      "Name": "SBQQ__PricingGuidance__r",
+      "ReferencedObject": "SBQQ__PricingGuidance__c",
+      "ReferencedFields": {
+        "GearsetExternalId__c": ""
+      }
+    },
+    {
+      "Name": "SBQQ__RenewalProduct__r",
+      "ReferencedObject": "Product2",
+      "ReferencedFields": {
+        "GearsetExternalId__c": ""
+      }
+    },
+    {
+      "Name": "SBQQ__SubscriptionTarget__r",
+      "ReferencedObject": "Product2",
+      "ReferencedFields": {
+        "GearsetExternalId__c": ""
+      }
+    },
+    {
+      "Name": "SBQQ__TermDiscountSchedule__r",
+      "ReferencedObject": "SBQQ__DiscountSchedule__c",
+      "ReferencedFields": {
+        "GearsetExternalId__c": ""
+      }
+    },
+    {
+      "Name": "SBQQ__UpgradeCredit__r",
+      "ReferencedObject": "Product2",
+      "ReferencedFields": {
+        "GearsetExternalId__c": ""
+      }
+    },
+    {
+      "Name": "SBQQ__UpgradeSource__r",
+      "ReferencedObject": "Product2",
+      "ReferencedFields": {
+        "GearsetExternalId__c": ""
+      }
+    },
+    {
+      "Name": "SBQQ__UpgradeTarget__r",
+      "ReferencedObject": "Product2",
+      "ReferencedFields": {
+        "GearsetExternalId__c": ""
+      }
+    }
+  ]
+}

--- a/configdata/gearset-config-data-project.json
+++ b/configdata/gearset-config-data-project.json
@@ -1,0 +1,6 @@
+{
+  "Packages": [
+    "Cpq"
+  ],
+  "Version": 1
+}

--- a/unpackaged/main/default/globalValueSets/Outlet_Standard.globalValueSet-meta.xml
+++ b/unpackaged/main/default/globalValueSets/Outlet_Standard.globalValueSet-meta.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<GlobalValueSet xmlns="http://soap.sforce.com/2006/04/metadata">
+    <customValue>
+        <fullName>TypeA</fullName>
+        <default>true</default>
+        <label>Type A (North America)</label>
+    </customValue>
+    <customValue>
+        <fullName>TypeC</fullName>
+        <default>false</default>
+        <label>Type C (Europe)</label>
+    </customValue>
+    <customValue>
+        <fullName>TypeG</fullName>
+        <default>false</default>
+        <label>Type G (UK/Ireland)</label>
+    </customValue>
+    <customValue>
+        <fullName>TypeI</fullName>
+        <default>false</default>
+        <label>Type I (Australia/New Zealand)</label>
+    </customValue>
+    <customValue>
+        <fullName>TypeL</fullName>
+        <default>false</default>
+        <label>Type L (Italy)</label>
+    </customValue>
+    <masterLabel>Outlet Standard</masterLabel>
+    <sorted>false</sorted>
+</GlobalValueSet>


### PR DESCRIPTION
## What has changed?
- Added new Pricebook2 record for "2023 Vehicle Price Book" with inactive status.
- Added two PricebookEntry records:
  - Active entry for "2023 Vehicle Price Book - Pickup Truck" with unit price 55,000.
  - Inactive entry for "Standard Price Book - Pickup Truck" with unit price 60,000.
- Added new Product2 record for "Pickup Truck" with detailed CPQ-related fields.
- Added Gearset config data project file specifying dependency on "Cpq" package.
- Added new global value set "Outlet_Standard" with multiple custom values representing regional types.

## What's the impact of these changes?
- Introduces new product and pricing data for vehicle-related catalogues.
- May affect quoting and sales processes relying on these price books and products.
- The inactive status on some pricebook entries and pricebook may prevent unintended usage.
- The global value set addition impacts picklist options where "Outlet_Standard" is used.
- Dependency on CPQ package may require ensuring package availability in target orgs.

## What should reviewers pay attention to?
- Correctness of references between PricebookEntry, Pricebook2, and Product2 via external IDs.
- Accuracy of pricing and active/inactive flags to avoid sales process issues.
- Completeness and correctness of CPQ-related Product2 fields.
- Proper definition and labels in the new global value set for intended usage.
- Gearset config file correctly specifies package dependencies.

## Testing recommendations
- Manual testing of product visibility and pricing in CPQ quoting UI.
- Verify that inactive pricebook and entries do not appear in active selections.
- Confirm picklist values for "Outlet_Standard" appear correctly in relevant UI.
- Regression test sales and quoting flows involving these products and pricebooks.
- *No unit tests affected or added as this is configuration data only.*