### PR TITLE
MP-71/CPQ Custom Field Update

### DIFF
--- a/unpackaged/main/default/objects/Account/fields/CPQ_Custom_Field__c.field-meta.xml
+++ b/unpackaged/main/default/objects/Account/fields/CPQ_Custom_Field__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>CPQ_Custom_Field__c</fullName>
+    <externalId>false</externalId>
+    <label>CPQ Custom Field</label>
+    <length>45</length>
+    <required>false</required>
+    <trackFeedHistory>false</trackFeedHistory>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>


### PR DESCRIPTION
## What has changed?
- Added a new custom text field `CPQ_Custom_Field__c` to the Account object.
- Field properties: 45 characters max length, not required, not unique, no feed tracking.

## What's the impact of these changes?
- Functional: Enables storage of additional CPQ-related data on Account records.
- No impact on existing functionality or security as field is not required or unique.
- Potential downstream effects include updates needed in integrations, reports, or layouts to utilize the new field.

## What should reviewers pay attention to?
- Confirm field length and type meet business requirements.
- Verify no conflicts with existing Account fields or integrations.
- Check if field-level security and page layouts need updates to expose this field appropriately.

## Testing recommendations
- Manual testing: Create and update Account records with values in the new field.
- Verify field visibility and editability per profile permissions.
- Regression: Ensure no impact on Account-related processes or automations.
- No unit tests affected as this is a metadata-only change.