### PR TITLE
MP-84/Salesforce-Custom-Field-Enhancements

### DIFF
--- a/unpackaged/main/default/objects/Account/fields/Formula_Field__c.field-meta.xml
+++ b/unpackaged/main/default/objects/Account/fields/Formula_Field__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Formula_Field__c</fullName>
+    <externalId>false</externalId>
+    <label>Formula Field</label>
+    <length>45</length>
+    <required>false</required>
+    <trackFeedHistory>false</trackFeedHistory>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>


### PR DESCRIPTION
## What has changed?
- Added a new custom text field `Formula_Field__c` to the Account object metadata.

## What's the impact of these changes?
- Introduces a new 45-character text field on Account records.
- No immediate functional impact unless referenced by automation, UI, or integrations.
- Potential for future use in formulas, validation, or display.

## What should reviewers pay attention to?
- Confirm field properties such as length, label, and type meet requirements.
- Verify no conflicts with existing fields or naming conventions.

## Testing recommendations
- Manual testing to verify the field appears on Account layouts if added.
- Check for any automation or integrations that may need updating to utilize the new field.
- No unit tests affected as this is a metadata addition only.