### PR TITLE
MP-87/Pricing-Tier-Field-for-Account

### DIFF
--- a/unpackaged/main/default/objects/Account/fields/Pricing_Tier__c.field-meta.xml
+++ b/unpackaged/main/default/objects/Account/fields/Pricing_Tier__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Pricing_Tier__c</fullName>
+    <externalId>false</externalId>
+    <label>Pricing Tier</label>
+    <length>40</length>
+    <required>false</required>
+    <trackFeedHistory>false</trackFeedHistory>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>


### PR DESCRIPTION
## What has changed?
- Added a new custom field `Pricing_Tier__c` to the Account object.
- The field is a non-required, non-unique Text field with a length of 40 characters.

## What's the impact of these changes?
- Functionally, this introduces a new attribute to Accounts for categorizing or segmenting by pricing tier.
- No direct impact on existing functionality or data integrity as the field is optional and non-unique.
- Downstream processes, reports, or integrations may leverage this field once populated.

## What should reviewers pay attention to?
- Confirm the field properties (length, type, required status) align with business requirements.
- Check for any existing automation or validation rules that might need updates to incorporate this new field.
- Review potential impacts on page layouts or user permissions related to this field.

## Testing recommendations
- Manual testing to verify the field appears correctly on Account records and can be edited.
- Validate that no errors occur when creating or updating Accounts without this field populated.
- Regression testing on Account-related processes to ensure no unintended side effects.
- No unit test changes required as this is a metadata addition only.