### PR TITLE
MP-88/Parent-Account-Checkbox

### DIFF
--- a/unpackaged/main/default/objects/Account/fields/Parent_Account_Field__c.field-meta.xml
+++ b/unpackaged/main/default/objects/Account/fields/Parent_Account_Field__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Parent_Account_Field__c</fullName>
+    <externalId>false</externalId>
+    <label>Parent Account Field</label>
+    <length>15</length>
+    <required>false</required>
+    <trackFeedHistory>false</trackFeedHistory>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>


### PR DESCRIPTION
## What has changed?
- Added a new custom text field `Parent_Account_Field__c` to the Account object.
- Field properties: 15 characters length, not required, not unique, no feed history tracking.

## What's the impact of these changes?
- Functional: Enables storing additional parent account information as text on Account records.
- No direct security or performance impact.
- Downstream effects may include updates to integrations, reports, or UI components referencing Account fields.

## What should reviewers pay attention to?
- Confirm field properties align with business requirements.
- Check for any necessary updates to page layouts, validation rules, or automation that should include this new field.
- Review potential impact on integrations or data imports involving Account.

## Testing recommendations
- Manual testing: Create and update Account records with values in the new field.
- Verify field visibility and editability in relevant profiles and page layouts.
- Regression: Ensure no existing Account functionality is broken.
- No unit tests affected as this is a metadata addition only.