### PR TITLE
MP-123/Purchasing-Agreement-Update

### DIFF
--- a/unpackaged/main/default/objects/Account/fields/Purchasing_agreement_signed__c.field-meta.xml
+++ b/unpackaged/main/default/objects/Account/fields/Purchasing_agreement_signed__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Purchasing_agreement_signed__c</fullName>
+    <externalId>false</externalId>
+    <label>Purchasing agreement signed</label>
+    <length>45</length>
+    <required>false</required>
+    <trackFeedHistory>false</trackFeedHistory>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>


### PR DESCRIPTION
## What has changed?
- Added a new custom text field `Purchasing_agreement_signed__c` to the Account object.
- Field properties: 45 characters length, not required, not unique, no feed history tracking.

## What's the impact of these changes?
- Functional: Enables tracking of whether a purchasing agreement is signed on Account records.
- No impact on existing functionality or security as the field is optional and has no unique constraints.
- Potential downstream effects include updates to UI layouts, reports, or integrations that may use this field.

## What should reviewers pay attention to?
- Confirm field length and type meet business requirements.
- Verify no unintended permission or visibility issues arise from the new field.
- Check if any layouts or automation need updating to incorporate this field.

## Testing recommendations
- Manual testing: Create and update Account records with values in the new field.
- Verify field visibility and editability in relevant profiles and page layouts.
- Regression: Ensure no existing Account functionality is broken.
- No unit tests added or modified as this is a metadata-only change.