### PR TITLE
MP-209/Billing-Cycle-Start-Date

### DIFF
--- a/unpackaged/main/default/objects/Account/fields/Billing_Cycle_Start_Date__c.field-meta.xml
+++ b/unpackaged/main/default/objects/Account/fields/Billing_Cycle_Start_Date__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Billing_Cycle_Start_Date__c</fullName>
+    <externalId>false</externalId>
+    <label>Billing Cycle Start Date</label>
+    <length>55</length>
+    <required>false</required>
+    <trackFeedHistory>false</trackFeedHistory>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/unpackaged/main/default/objects/Account/fields/Purchase_Order_Signed__c.field-meta.xml
+++ b/unpackaged/main/default/objects/Account/fields/Purchase_Order_Signed__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Purchase_Order_Signed__c</fullName>
+    <externalId>false</externalId>
+    <label>Purchase Order Signed?</label>
+    <length>80</length>
+    <required>false</required>
+    <trackFeedHistory>false</trackFeedHistory>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>


### PR DESCRIPTION
## What has changed?
- Added a new custom field `Billing_Cycle_Start_Date__c` to the Account object.
- The field is of type Text with a length of 55 characters.
- The field is not required, not unique, and does not track feed history.

## What's the impact of these changes?
- Functionally, this adds a new attribute to Account records to store billing cycle start dates as text.
- No immediate impact on existing functionality or data integrity.
- Downstream processes or integrations referencing Account may need updates to utilize this new field.

## What should reviewers pay attention to?
- Confirm the appropriateness of the field type (Text) and length (55) for billing cycle start dates.
- Verify that the field's metadata settings align with business requirements (e.g., not required, no uniqueness).
- Consider if any validation rules or automation should be added to enforce correct data format.

## Testing recommendations
- Manual testing: Create and update Account records with various values in the new Billing Cycle Start Date field.
- Regression testing: Ensure no existing Account functionality is broken by the addition of this field.
- No unit test classes were added or modified in this change.