### PR TITLE
MP-224/Social-Security-Field

### DIFF
--- a/unpackaged/main/default/objects/Account/fields/Social_Security_Digits__c.field-meta.xml
+++ b/unpackaged/main/default/objects/Account/fields/Social_Security_Digits__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Social_Security_Digits__c</fullName>
+    <externalId>false</externalId>
+    <label>Social Security Digits</label>
+    <length>45</length>
+    <required>false</required>
+    <trackFeedHistory>false</trackFeedHistory>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>


### PR DESCRIPTION
## What has changed?
- Added a new custom text field `Social_Security_Digits__c` to the Account object.
- Field length is set to 45 characters, not required, and not unique.

## What's the impact of these changes?
- Introduces a new field to store social security digits on Account records.
- No immediate impact on existing functionality or data.
- Potentially sensitive data storage; security and access controls should be reviewed.

## What should reviewers pay attention to?
- Confirm field length and type are appropriate for intended use.
- Review field-level security and sharing settings to protect sensitive data.
- Validate compliance with data privacy policies regarding social security information.

## Testing recommendations
- Manual testing to verify the field appears on Account layouts as expected.
- Check that users with appropriate permissions can view and edit the field.
- Verify that users without permissions cannot access the field.
- No unit test changes required as this is a metadata addition only.