### PR TITLE
MP-229/Partner-Management-Field

### DIFF
--- a/unpackaged/main/default/objects/Account/fields/Account_Query__c.field-meta.xml
+++ b/unpackaged/main/default/objects/Account/fields/Account_Query__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Account_Query__c</fullName>
+    <externalId>false</externalId>
+    <label>Account Query</label>
+    <length>45</length>
+    <required>false</required>
+    <trackFeedHistory>false</trackFeedHistory>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/unpackaged/main/default/objects/Account/fields/Partner_Management__c.field-meta.xml
+++ b/unpackaged/main/default/objects/Account/fields/Partner_Management__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Partner_Management__c</fullName>
+    <externalId>false</externalId>
+    <label>Partner Management</label>
+    <length>56</length>
+    <required>false</required>
+    <trackFeedHistory>false</trackFeedHistory>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>


### PR DESCRIPTION
## What has changed?
- Added two new custom text fields to the Account object:
 - `Account_Query__c` with length 45.
 - `Partner_Management__c` with length 56.

## What's the impact of these changes?
- Functional impact includes additional data capture capabilities on Account records.
- No changes to field-level security or required status, so no immediate access or validation impacts.
- Potential downstream effects if integrations or reports start using these new fields.

## What should reviewers pay attention to?
- Confirm field definitions meet business requirements (length, label).
- Verify no unintended permission or validation rule changes.
- Consider if any automation or integrations need updates to handle these new fields.

## Testing recommendations
- Manual testing to verify new fields appear on Account layouts if applicable.
- Validate data entry and storage for these fields.
- Regression testing on Account-related processes to ensure no side effects.
- No unit test classes affected or added.